### PR TITLE
fix: Verify's callback receives just Express.User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## 1.2.2 - 2022-12-21
-### Added
-- Added a new option for passing the user in the Verify Callback, (Express.User)
 
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Types: Callback from `verify` should receive an `Express.User` object instead of `ProfileWithMetaData`
 
 ## 1.2.1 - 2022-12-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 1.2.2 - 2022-12-21
+### Added
+- Added a new option for passing the user in the Verify Callback, (Express.User)
 
 ## Unreleased
 

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -50,7 +50,10 @@ export class Strategy extends OAuth2Strategy {
       accessToken: string,
       refreshToken: string,
       profile: ProfileWithMetaData,
-      done: (error: Error | null, user?: ProfileWithMetaData) => void
+      done: (
+        error: Error | null,
+        user?: ProfileWithMetaData | Express.User
+      ) => void
     ) => void
   ) {
     options = options || {};

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -50,10 +50,7 @@ export class Strategy extends OAuth2Strategy {
       accessToken: string,
       refreshToken: string,
       profile: ProfileWithMetaData,
-      done: (
-        error: Error | null,
-        user?: ProfileWithMetaData | Express.User
-      ) => void
+      done: (error: Error | null, user?: Express.User) => void
     ) => void
   ) {
     options = options || {};


### PR DESCRIPTION
Follow up to #27 to keep the history and changes more transparent.