### PR TITLE
Type-safe support for verify function with request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 1.2.4-beta.0 - 2024-01-29
 ### Fixed
 - Type-safe support for verify function with request
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Type-safe support for verify function with request
 
 ## 1.2.3 - 2023-01-13
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superfaceai/passport-twitter-oauth2",
-  "version": "1.2.3",
+  "version": "1.2.4-beta.0",
   "description": "Twitter OAuth 2.0 authentication strategy for Passport.",
   "source": "src/index.ts",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export type {
   Profile,
   ProfileWithMetaData,
   StrategyOptions,
-  StrategyOptionWithRequest,
+  StrategyOptionsWithRequest,
   AuthenticateOptions,
 } from './models';
 export { Strategy };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,6 @@
 export type { Profile, ProfileWithMetaData } from './profile';
 export type {
   StrategyOptions,
-  StrategyOptionWithRequest,
+  StrategyOptionsWithRequest,
   AuthenticateOptions,
 } from './strategyOptions';

--- a/src/models/strategyOptions.ts
+++ b/src/models/strategyOptions.ts
@@ -24,7 +24,7 @@ export interface StrategyOptions
 /**
  * @public
  */
-export interface StrategyOptionWithRequest
+export interface StrategyOptionsWithRequest
   extends TwitterStrategyOptionsBase,
     Omit<
       PassportOAuth2StrategyOptionsWithRequest,
@@ -32,6 +32,18 @@ export interface StrategyOptionWithRequest
     > {
   passReqToCallback: true;
 }
+
+export const isStrategyOptions = (
+  options: StrategyOptions | StrategyOptionsWithRequest
+): options is StrategyOptions => {
+  return !options.passReqToCallback;
+};
+
+export const isStrategyOptionsWithRequest = (
+  options: StrategyOptions | StrategyOptionsWithRequest
+): options is StrategyOptionsWithRequest => {
+  return options.passReqToCallback === true;
+};
 
 /**
  * @public


### PR DESCRIPTION
This PR fixes issue #43 and adds type safe support for using verify function with request parameter.