### PR TITLE
update default authorizationURL

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -93,7 +93,7 @@ export class Strategy extends OAuth2Strategy {
     const options = userOptions || {};
     options.sessionKey = options.sessionKey || 'oauth:twitter';
     const authorizationURL =
-      options.authorizationURL || 'https://twitter.com/i/oauth2/authorize';
+      options.authorizationURL || 'https://x.com/i/oauth2/authorize';
     const tokenURL =
       options.tokenURL || 'https://api.twitter.com/2/oauth2/token';
 

--- a/test/strategy.test.ts
+++ b/test/strategy.test.ts
@@ -60,7 +60,7 @@ describe('issuing authorization request', function () {
     it('should be redirected', function () {
       const parsedUrl = new URL(url);
 
-      expect(parsedUrl.host).to.equal('twitter.com');
+      expect(parsedUrl.host).to.equal('x.com');
       expect(parsedUrl.pathname).to.equal('/i/oauth2/authorize');
       expect(parsedUrl.searchParams.get('response_type')).to.equal('code');
       expect(parsedUrl.searchParams.get('code_challenge')).to.exist;


### PR DESCRIPTION
Although the current authorizationURL works with a single twitter account, after migration of twitter to x.com, there is a annoying bug that always presents the same user account for authorization for users who have more than 1 twitter accounts. Ideally, the authorization request should be prompted for the selected account on twitter.

Updating the authorizationURL to use x.com domain fixes this problem.

https://devcommunity.x.com/t/oauth-2-0-causes-users-to-be-presented-with-a-login-screen-with-a-different-account-than-the-one-selected-on-x-com/223915